### PR TITLE
Leave JSON conversion to underlying library

### DIFF
--- a/recombee_api_client/api_client.py
+++ b/recombee_api_client/api_client.py
@@ -40,7 +40,7 @@ class RecombeeClient:
         """
         @param request: Request to be sent to Recombee recommender
         """
-        
+
         if isinstance(request, Batch) and len(request.requests) > self.BATCH_MAX_SIZE:
             return self.__send_multipart_batch(request)
 
@@ -69,8 +69,8 @@ class RecombeeClient:
         return headers
 
     def __put(self, request, uri, timeout):
-        response = requests.put(uri, 
-                                data=json.dumps(request.get_body_parameters()),
+        response = requests.put(uri,
+                                json=request.get_body_parameters(),
                                 headers= self.__get_http_headers({'Content-Type': 'application/json'}),
                                 timeout=timeout)
         self.__check_errors(response, request)
@@ -85,7 +85,7 @@ class RecombeeClient:
 
     def __post(self, request, uri, timeout):
         response = requests.post(uri,
-                                data=json.dumps(request.get_body_parameters()), 
+                                json=request.get_body_parameters(),
                                 headers= self.__get_http_headers({'Content-Type': 'application/json'}),
                                 timeout=timeout)
         self.__check_errors(response, request)


### PR DESCRIPTION
JSON conversion should be done by the underlying [`requests` library](https://github.com/requests/requests/blob/master/requests/models.py#L466) which should choose appropriate library for JSON conversion (currently it seems to be [either `json` or `simplejson`](https://github.com/requests/requests/blob/master/requests/compat.py#L29)).
